### PR TITLE
Add support for Farnsworth speed

### DIFF
--- a/src/morsify.js
+++ b/src/morsify.js
@@ -220,7 +220,10 @@
       } else if (morse[i] === options.dash) {
         tone(3);
         silence(1);
-      } else {
+      } else if (
+        (typeof morse[i + 1] !== 'undefined' && morse[i + 1] !== options.space) &&
+        (typeof morse[i - 1] !== 'undefined' && morse[i - 1] !== options.space)
+      ) {
         silence(3);
       }
     }

--- a/src/morsify.js
+++ b/src/morsify.js
@@ -144,6 +144,7 @@
       invalid: options.invalid || '#',
       priority: options.priority || 1,
       unit: options.unit || 0.08, // period of one unit, in seconds, 1.2 / c where c is speed of transmission, in words per minute
+      fwUnit: options.fwUnit || options.unit || 0.08, // Farnsworth unit to control intercharacter and interword gaps
       oscillator: {
         type: options.oscillator.type || 'sine', // sine, square, sawtooth, triangle
         frequency: options.oscillator.frequency || 500,  // value in hertz
@@ -211,9 +212,14 @@
       t += i * options.unit;
     };
 
+    const gap = (i) => {
+      gainNode.gain.setValueAtTime(0, t);
+      t += i * options.fwUnit;
+    };
+
     for (let i = 0; i <= morse.length; i++) {
       if (morse[i] === options.space) {
-        silence(7);
+        gap(7);
       } else if (morse[i] === options.dot) {
         tone(1);
         silence(1);
@@ -224,7 +230,7 @@
         (typeof morse[i + 1] !== 'undefined' && morse[i + 1] !== options.space) &&
         (typeof morse[i - 1] !== 'undefined' && morse[i - 1] !== options.space)
       ) {
-        silence(3);
+        gap(3);
       }
     }
 


### PR DESCRIPTION
This PR adds support for the [Farnsworth speed](https://en.wikipedia.org/wiki/Morse_code#Farnsworth_speed), which controls the speed at which intercharacter and interword gaps are sent. This isn't a breaking change because it falls back to the `options.unit` if it's not specified. As the WPM unit isn't calculated in this library, I've also not included the FWPM calculation either.

Additionally, it fixes incorrect spacing between words. Right now, the library produces 13 dots of silence (intercharacter + interword + intercharacter) between words, instead of the expected 7.