### PR TITLE
Wave export

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ const characters = morsify.characters(); // {'1': {'A': '.-', ...}, ..., '11': {
 const audio = morsify.audio('SOS');
 audio.play(); // play audio
 audio.stop(); // stop audio
+audio.exportWave(); // download audio wave file (promise)
+const url = await audio.getWaveUrl(); // get audio wave url (promise)
+const blob = await audio.getWaveBlob(); // get audio wave blob (promise)
 ```
 
 Alternatively, you can use the library directly with including the source file.
@@ -45,6 +48,9 @@ Alternatively, you can use the library directly with including the source file.
     var gainNode = audio.gainNode; // GainNode
     audio.play(); // play audio
     audio.stop(); // stop audio
+    audio.exportWave(); // download audio wave file (promise)
+    var url = await audio.getWaveUrl(); // get audio wave url (promise)
+    var blob = await audio.getWaveBlob(); // get audio wave blob (promise)
 </script>
 ```
 

--- a/src/morsify.js
+++ b/src/morsify.js
@@ -232,6 +232,7 @@
     }
   }
 
+  // graciously borrowed from: https://github.com/mattdiamond/Recorderjs/blob/master/src/recorder.js
   const encodeWAV = (sampleRate, samples) => {
     let buffer = new ArrayBuffer(44 + samples.length * 2);
     let view = new DataView(buffer);
@@ -302,6 +303,7 @@
     gainNode.connect(offlineContext.destination);
     source.onended = options.oscillator.onended;
 
+    // offline rendering as a promise inspired by: http://joesul.li/van/tale-of-no-clocks/
     let render = new Promise(resolve => {
       oscillator.start(0);
       offlineContext.startRendering();
@@ -313,7 +315,8 @@
     
     let timeout;
 
-    const play = () => {
+    const play = async () => {
+      await render;
       source.start(context.currentTime);
       timeout = setTimeout(() => stop(), totalTime * 1000);
     };


### PR DESCRIPTION
This is my resolution for #16 - it adds the following methods to the export:
- exportWave - immediately download a wave representation of the morsify audio
- getWaveUrl - gets an object url for the wave blob (e.g. for sending to an audio player - see example below)
- getWaveBlob - gets the underlying wave blob

A demo of these functions can be found here: https://chris--jones.github.io/morsify/

@ozdemirburak - Some things to note:
Rather than duplicate all the nodes for both the offline and regular audio context I was able to render via the offline context and store the buffer as an AudioBufferSourceNode which can then be played via the audio context.

This approach keeps the audio data in memory so that multiple export operations can be applied (e.g. you can download multiple times from the same morsify.audio() instance, but you still cannot play multiple times because I do not re-instantiate the AudioBufferSourceNode (I believe this behaviour is unchanged).

I did move the context variables into the audio function - I wasn't sure why they should exist beyond the lifetime of the audio function, but it was causing issues for the offline rendering; I think enforcing the recreation of context / buffer source for play operations should also allow for multiple play operations against the same morsify.audio() instance if desirable.

I also split out processing the gain values as this also provides the total duration time required for the offline audio context.
